### PR TITLE
Edit website name, index and about text

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,7 +6,7 @@ project:
     - "!internal/"
 
 website:
-  title: "howto"
+  title: "How-to guides"
   google-analytics: "G-XZ471458FQ"
   navbar:
     logo: logo_white.svg

--- a/about.qmd
+++ b/about.qmd
@@ -2,11 +2,11 @@
 title: "About"
 ---
 
-## What are the key principles of a How-to guide?
+## What is a How-to guide?
 
 [How-to guides](https://diataxis.fr/how-to-guides/) are directions that guide the reader through a problem or towards a result. How-to guides are goal-oriented.
 
-A [How-to guide](https://diataxis.fr/how-to-guides/#key-principles) is concerned with work - a task or problem, with a practical goal. Maintain focus on that goal.
+A how-to guide is concerned with work - a task or problem, with a practical goal. Maintain focus on that goal.
 
 A how-to guide serves the work of the already-competent user, whom you can assume to know what they want to do, and to be able to follow your instructions correctly.
 

--- a/about.qmd
+++ b/about.qmd
@@ -4,9 +4,9 @@ title: "About"
 
 ## What are the key principles of a How-to guide?
 
-How-to guides will help you complete a specific outbreak analytic task following concrete steps to solve a real-world problem.
+[How-to guides](https://diataxis.fr/how-to-guides/) are directions that guide the reader through a problem or towards a result. How-to guides are goal-oriented.
 
-A [how to-guide](https://diataxis.fr/how-to-guides/#key-principles) is concerned with work - a task or problem, with a practical goal. Maintain focus on that goal.
+A [How-to guide](https://diataxis.fr/how-to-guides/#key-principles) is concerned with work - a task or problem, with a practical goal. Maintain focus on that goal.
 
 A how-to guide serves the work of the already-competent user, whom you can assume to know what they want to do, and to be able to follow your instructions correctly.
 

--- a/index.qmd
+++ b/index.qmd
@@ -20,7 +20,9 @@ listing:
     fields: [title]
 ---
 
-The Epiverse-TRACE **How-to guides** aim to collect recipe-like reproducible scripts to complete specific Outbreak analytics tasks following concrete steps using `R` packages.
+The Epiverse-TRACE **How-to guides** aim to collect recipe-like reproducible scripts to complete specific Outbreak analytics tasks following concrete steps using `R` packages. [^1] 
+
+[^1]: Refer to the [About](about.qmd) page for more details about the rationale behind the design of this site.
 
 ## Describe case data
 
@@ -42,8 +44,6 @@ The Epiverse-TRACE **How-to guides** aim to collect recipe-like reproducible scr
 :::{#simulate-transmission}
 :::
 
-## More
+## Contribute
 
 Follow our guidelines on [Getting help](https://github.com/epiverse-trace/howto/blob/main/.github/SUPPORT.md) with and [Contributing](https://github.com/epiverse-trace/howto/blob/main/.github/CONTRIBUTING.md) to the `howto` repository.
-
-Refer to the [About](about.qmd) page for more details about the rationale behind the design of this site.

--- a/index.qmd
+++ b/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Get started"
+title: "Epiverse-TRACE How-to guides"
 fig-cap-location: top
 listing: 
   - id: describe-cases
@@ -20,7 +20,7 @@ listing:
     fields: [title]
 ---
 
-The goal of `howto` is to collect reproducible How to guides of Outbreak data analysis tasks using `R` packages.
+The Epiverse-TRACE **How-to guides** aim to collect recipe-like reproducible scripts to complete specific Outbreak analytics tasks following concrete steps using `R` packages.
 
 ## Describe case data
 


### PR DESCRIPTION
This PR proposes to use the "How-to guides" name on the navbar, "Epiverse-TRACE How-to guides" as index title for cellphone visibility, plus edits on the index and about text to fix and simplify some content.