### PR TITLE
Update R0 to 2 in finalsize_heterogenious_between_within.Rmd

### DIFF
--- a/analyses/simulate_transmission/finalsize_heterogenious_between_within.qmd
+++ b/analyses/simulate_transmission/finalsize_heterogenious_between_within.qmd
@@ -95,7 +95,7 @@ p_susceptibility <- tibble(
 p_susceptibility
 
 # R0 of the disease
-r0 <- 1.5 # assumed for pandemic influenza
+r0 <- 2 # assumed for pandemic influenza
 
 # Calculate the proportion of individuals infected in each age group
 final_size(


### PR DESCRIPTION
This is a small PR that changes $R_0 = 2$ in the [finalsize howto](https://epiverse-trace.github.io/howto/analyses/simulate_transmission/finalsize_heterogenious_between_within.html), because the version with $R_0 = 1.5$ seems to produce no outbreak because not enough susceptibility (values basically zero).

- [ X] I have read the CONTRIBUTING guidelines
