### PR TITLE
docs: add console-ready render chunks to CONTRIBUTING and README

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -92,6 +92,16 @@ Use the [**Render** button](https://quarto.org/docs/get-started/hello/rstudio.ht
 
 To render the whole website, use the **Render Website** button within the [Build pane](https://docs.posit.co/ide/user/ide/guide/ui/ui-panes.html).
 
+Alternatively, run in the R console:
+
+```r
+# Preview a single file with live reload
+quarto::quarto_preview("analyses/<task>/file.qmd")
+
+# Render the whole website
+quarto::quarto_render()
+```
+
 If the task (folder) of your entry is not listed in the `index.qmd` page, First, add a new task entry to the `listing:` section in the YAML on top. In the template below, edit the `id:` and `contents:` with for the corresponding task (folder name). For example, for the task `"Describe case data"` with used as ID `describe-cases` and detailed the folder path `analyses/describe_cases/*.qmd`:
 
 ```

--- a/README.Rmd
+++ b/README.Rmd
@@ -24,6 +24,11 @@ The goal of `{howto}` is to collect reproducible **how-to guides** of Outbreak d
 
 Visualize this content as a webpage at <https://epiverse-trace.github.io/howto/>
 
+```{r, eval = FALSE}
+# Render the website locally
+quarto::quarto_render()
+```
+
 ## Contributing
 
 Contributions are always welcome!

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Outbreak data analysis tasks using `R` packages.
 Visualize this content as a webpage at
 <https://epiverse-trace.github.io/howto/>
 
+``` r
+# Render the website locally
+quarto::quarto_render()
+```
+
 ## Contributing
 
 Contributions are always welcome!
@@ -39,9 +44,7 @@ Please see our [Getting help guide](/.github/SUPPORT.md) for support.
 
 ## Citation
 
-    #> 
-    #> Valle A (2023). "howto: How-To Guides For Outbreak Analytics R
-    #> Packages."
+    #> Valle A (2023). "howto: How-To Guides For Outbreak Analytics R Packages."
     #> 
     #> A BibTeX entry for LaTeX users is
     #> 


### PR DESCRIPTION
## Summary

- Adds R console alternative (`quarto::quarto_preview()` / `quarto::quarto_render()`) to CONTRIBUTING.md § 5.5 "Build locally", alongside the existing RStudio GUI instructions
- Adds a `quarto::quarto_render()` chunk to the README Usage section for local rendering

## Notes

`README.Rmd` must be re-knit manually via RStudio before committing, as pandoc is not on the system PATH outside of RStudio. See the new "Rendering locally" section in `CLAUDE.md` for details.

## Test plan

- [ ] Verify `quarto::quarto_render()` builds the site to `docs/` without errors
- [ ] Verify `quarto::quarto_preview()` opens a live-reload preview
- [ ] Confirm `README.md` renders cleanly from `README.Rmd` in RStudio

🤖 Generated with [Claude Code](https://claude.com/claude-code)